### PR TITLE
fix: preserve missing SOPS subprocess broadcast content

### DIFF
--- a/src/manager/handler/api/bk_sops.py
+++ b/src/manager/handler/api/bk_sops.py
@@ -22,6 +22,7 @@ sops_instance_status_map = {
     "FAILED": TaskExecStatus.FAIL.value,  # 失败
     "FINISHED": TaskExecStatus.SUCCESS.value,  # 已完成
     "SUSPENDED": TaskExecStatus.SUSPENDED.value,  # 暂停
+    "NODE_SUSPENDED": TaskExecStatus.SUSPENDED.value,  # 节点暂停
     "REVOKED": TaskExecStatus.REMOVE.value,  # 已终止
 }
 

--- a/src/manager/module_biz/handlers/platform_task.py
+++ b/src/manager/module_biz/handlers/platform_task.py
@@ -278,27 +278,27 @@ def parse_sops_pipeline_tree(task_info, status_info, is_parse_all=False):
 
             parse_data.append(current_parse_data)
             if node["type"] == "SubProcess":
-                if node_status_info.get("children"):
-                    _unfold_pipeline_tree(
-                        node["pipeline"],
-                        node_status_info.get("children"),
-                        parse_data,
-                        current_step_index_list,
-                        current_step_detail,
-                    )
+                _unfold_pipeline_tree(
+                    node["pipeline"],
+                    node_status_info.get("children") or {},
+                    parse_data,
+                    current_step_index_list,
+                    current_step_detail,
+                )
 
-    _unfold_pipeline_tree(pipeline_tree, status_info.get("children"), parse_result, [], current_step_detail)
+    _unfold_pipeline_tree(pipeline_tree, status_info.get("children") or {}, parse_result, [], current_step_detail)
     running_index = parse_result[0]
     parse_result = parse_result[1:]
     total_step_num = len(parse_result)
     task_state = sops_instance_status_map[status_info.get("state")]
+    current_step_num = 0
     if task_state in TASK_STATUS_INIT:
         current_step_num = 0
     elif task_state in TASK_STATUS_SUCCESS:
         current_step_num = total_step_num
     else:
         for index, item in enumerate(parse_result):
-            if item["step_status"] in {"执行中", "执行失败"}:
+            if item["step_status"] in {"执行中", "执行失败", "暂停", "执行终止"}:
                 current_step_num = index + 1
                 break
 
@@ -307,6 +307,8 @@ def parse_sops_pipeline_tree(task_info, status_info, is_parse_all=False):
         if task_state in TASK_STATUS_INIT:
             parse_result = parse_result[:5]
         if task_state in TASK_STATUS_UNFINISHED:
+            if running_index is None:
+                running_index = max(current_step_num - 1, 0)
             _start = running_index - 2 if running_index - 2 > 0 else 0
             _end = running_index + 3
             for step in parse_result[_end:]:

--- a/src/manager/module_biz/handlers/platform_task.py
+++ b/src/manager/module_biz/handlers/platform_task.py
@@ -196,6 +196,7 @@ def parse_sops_node_order(pipeline_tree):
 def parse_sops_pipeline_tree(task_info, status_info, is_parse_all=False):
     pipeline_tree = task_info.get("pipeline_tree")
     parse_result = [None]
+    supplemental_subprocess_steps = []
     current_step_detail = {"plugin_code": "", "step_id": ""}
 
     def _unfold_pipeline_tree(pipeline_data, status_data, parse_data, parent_step_index_list, cur_step_detail):
@@ -278,13 +279,22 @@ def parse_sops_pipeline_tree(task_info, status_info, is_parse_all=False):
 
             parse_data.append(current_parse_data)
             if node["type"] == "SubProcess":
+                subprocess_step_start = len(parse_data) - 1
+                subprocess_children = node_status_info.get("children") or {}
                 _unfold_pipeline_tree(
                     node["pipeline"],
-                    node_status_info.get("children") or {},
+                    subprocess_children,
                     parse_data,
                     current_step_index_list,
                     current_step_detail,
                 )
+                # A fast subprocess may finish before its runtime child tree is available.
+                if (
+                    node_id in status_data
+                    and node_status_info.get("state") != "CREATED"
+                    and not subprocess_children
+                ):
+                    supplemental_subprocess_steps.extend(parse_data[subprocess_step_start:])
 
     _unfold_pipeline_tree(pipeline_tree, status_info.get("children") or {}, parse_result, [], current_step_detail)
     running_index = parse_result[0]
@@ -311,8 +321,13 @@ def parse_sops_pipeline_tree(task_info, status_info, is_parse_all=False):
                 running_index = max(current_step_num - 1, 0)
             _start = running_index - 2 if running_index - 2 > 0 else 0
             _end = running_index + 3
-            for step in parse_result[_end:]:
-                if step["step_status"] in {"执行中", "执行失败"}:
+            supplemental_step_ids = {id(step) for step in supplemental_subprocess_steps}
+            for index, step in enumerate(parse_result):
+                if _start <= index < _end:
+                    continue
+                if (
+                    index >= _end and step["step_status"] in {"执行中", "执行失败"}
+                ) or id(step) in supplemental_step_ids:
                     else_executing_step_list.append(step)
             parse_result = parse_result[_start:_end]
         if task_state in TASK_STATUS_SUCCESS:

--- a/src/manager/module_biz/test/test_platform_task.py
+++ b/src/manager/module_biz/test/test_platform_task.py
@@ -5,6 +5,8 @@ from copy import deepcopy
 
 import pytest
 
+from src.manager.module_notice.handler.deal_boardcast_msg import OriginalBroadcast
+
 
 @pytest.fixture(scope="module")
 def parse_sops_pipeline_tree():
@@ -195,6 +197,51 @@ def test_unfolds_short_parallel_subprocess_when_runtime_children_are_empty(parse
     assert result["total_step_num"] == 5
 
 
+def test_supplements_short_parallel_subprocess_outside_five_step_window(parse_sops_pipeline_tree):
+    long_pipeline = linear_pipeline(
+        service("long-child-1", "long child 1"),
+        service("long-child-2", "long child 2"),
+        service("long-child-3", "long child 3"),
+        service("long-child-4", "long child 4"),
+        service("long-child-5", "long child 5"),
+    )
+    short_pipeline = linear_pipeline(
+        service("short-child-1", "short child 1"), service("short-child-2", "short child 2")
+    )
+    pipeline = parallel_pipeline(
+        subprocess("long", "long subprocess", long_pipeline),
+        subprocess("short", "short subprocess", short_pipeline),
+    )
+    status = task_status(
+        "RUNNING",
+        {
+            "long": {
+                "state": "RUNNING",
+                "children": {"long-child-1": {"state": "RUNNING", "children": {}}},
+            },
+            "short": {"state": "FINISHED", "children": {}},
+        },
+    )
+
+    result = parse_sops_pipeline_tree(task_info(pipeline), status, is_parse_all=False)
+
+    assert [step["step_name"] for step in result["step_data"]] == [
+        "long subprocess",
+        "long child 1",
+        "long child 2",
+        "long child 3",
+    ]
+    assert [step["step_name"] for step in result["else_executing_step_list"]] == [
+        "short subprocess",
+        "short child 1",
+        "short child 2",
+    ]
+    broadcast_text = OriginalBroadcast(result).text_content
+    assert "short subprocess" in broadcast_text
+    assert "short child 1" in broadcast_text
+    assert "short child 2" in broadcast_text
+
+
 def test_empty_runtime_children_keep_five_step_window_safe(parse_sops_pipeline_tree):
     child_pipeline = linear_pipeline(
         service("child-1", "child 1"),
@@ -209,7 +256,28 @@ def test_empty_runtime_children_keep_five_step_window_safe(parse_sops_pipeline_t
     result = parse_sops_pipeline_tree(task_info(pipeline), status, is_parse_all=False)
 
     assert [step["step_name"] for step in result["step_data"]] == ["subprocess", "child 1", "child 2"]
+    assert [step["step_name"] for step in result["else_executing_step_list"]] == [
+        "child 3",
+        "child 4",
+        "child 5",
+    ]
     assert len(result["step_data"]) <= 5
+
+
+def test_does_not_supplement_unstarted_subprocess(parse_sops_pipeline_tree):
+    child_pipeline = linear_pipeline(
+        service("child-1", "child 1"),
+        service("child-2", "child 2"),
+        service("child-3", "child 3"),
+        service("child-4", "child 4"),
+        service("child-5", "child 5"),
+    )
+    pipeline = linear_pipeline(subprocess("sub", "subprocess", child_pipeline))
+    status = task_status("RUNNING", {"sub": {"state": "CREATED", "children": {}}})
+
+    result = parse_sops_pipeline_tree(task_info(pipeline), status, is_parse_all=False)
+
+    assert result["else_executing_step_list"] == []
 
 
 def test_successful_task_still_filters_nodes_without_runtime_status(parse_sops_pipeline_tree):
@@ -229,9 +297,7 @@ def test_successful_task_still_filters_nodes_without_runtime_status(parse_sops_p
         ("REVOKED", "执行终止"),
     ],
 )
-def test_unfinished_special_states_generate_broadcast_result(
-    parse_sops_pipeline_tree, state, expected_status
-):
+def test_unfinished_special_states_generate_broadcast_result(parse_sops_pipeline_tree, state, expected_status):
     pipeline = linear_pipeline(service("node", "node"))
     status = task_status(state, {"node": {"state": state, "children": {}}})
 

--- a/src/manager/module_biz/test/test_platform_task.py
+++ b/src/manager/module_biz/test/test_platform_task.py
@@ -1,0 +1,221 @@
+import importlib
+import sys
+import types
+from copy import deepcopy
+
+import pytest
+
+
+@pytest.fixture(scope="module")
+def parse_sops_pipeline_tree():
+    monkeypatch = pytest.MonkeyPatch()
+    monkeypatch.setenv("BKAPP_JOB_HOST", "http://job.example.com")
+    monkeypatch.setenv("BKAPP_DEVOPS_HOST", "http://devops.example.com")
+
+    # platform_task only needs the status mappings from these modules. Stubbing
+    # the unrelated API clients keeps this parser unit test independent from
+    # Django and the legacy deployment dependencies.
+    adapter_api = types.ModuleType("adapter.api")
+    adapter_api.SopsApi = object()
+    monkeypatch.setitem(sys.modules, "adapter.api", adapter_api)
+
+    bk_job = types.ModuleType("src.manager.handler.api.bk_job")
+    bk_job.job_instance_status_map = {}
+    monkeypatch.setitem(sys.modules, "src.manager.handler.api.bk_job", bk_job)
+
+    devops = types.ModuleType("src.manager.handler.api.devops")
+    devops.dev_ops_instance_status_map = {}
+    monkeypatch.setitem(sys.modules, "src.manager.handler.api.devops", devops)
+
+    module_names = [
+        "src.manager.handler.api.bk_sops",
+        "src.manager.module_biz.handlers.platform_task",
+    ]
+    for module_name in module_names:
+        monkeypatch.delitem(sys.modules, module_name, raising=False)
+
+    module = importlib.import_module("src.manager.module_biz.handlers.platform_task")
+    yield module.parse_sops_pipeline_tree
+    monkeypatch.undo()
+
+
+def service(node_id, name):
+    return {
+        "id": node_id,
+        "name": name,
+        "type": "ServiceActivity",
+        "component": {"code": "noop", "data": {}},
+    }
+
+
+def subprocess(node_id, name, pipeline):
+    return {
+        "id": node_id,
+        "name": name,
+        "type": "SubProcess",
+        "pipeline": pipeline,
+    }
+
+
+def linear_pipeline(*raw_nodes):
+    nodes = [deepcopy(node) for node in raw_nodes]
+    flows = {}
+    start = {"id": "start", "type": "EmptyStartEvent", "outgoing": "flow-0"}
+    end = {"id": "end", "type": "EmptyEndEvent"}
+    previous = start["id"]
+
+    for index, node in enumerate(nodes):
+        incoming = "flow-{}".format(index)
+        outgoing = "flow-{}".format(index + 1)
+        flows[incoming] = {"id": incoming, "source": previous, "target": node["id"]}
+        node["incoming"] = incoming
+        node["outgoing"] = outgoing
+        previous = node["id"]
+
+    final_flow = "flow-{}".format(len(nodes))
+    flows[final_flow] = {"id": final_flow, "source": previous, "target": end["id"]}
+    end["incoming"] = final_flow
+
+    return {
+        "start_event": start,
+        "end_event": end,
+        "activities": {node["id"]: node for node in nodes},
+        "gateways": {},
+        "flows": flows,
+    }
+
+
+def parallel_pipeline(first_node, second_node):
+    first = deepcopy(first_node)
+    second = deepcopy(second_node)
+    gateway = {
+        "id": "parallel",
+        "name": "parallel",
+        "type": "ParallelGateway",
+        "incoming": "flow-start",
+        "outgoing": ["flow-first", "flow-second"],
+    }
+    converge = {
+        "id": "converge",
+        "name": "converge",
+        "type": "ConvergeGateway",
+        "incoming": ["flow-first-converge", "flow-second-converge"],
+        "outgoing": "flow-end",
+    }
+    first["incoming"] = "flow-first"
+    first["outgoing"] = "flow-first-converge"
+    second["incoming"] = "flow-second"
+    second["outgoing"] = "flow-second-converge"
+
+    return {
+        "start_event": {"id": "start", "type": "EmptyStartEvent", "outgoing": "flow-start"},
+        "end_event": {
+            "id": "end",
+            "type": "EmptyEndEvent",
+            "incoming": "flow-converge-end",
+            "outgoing": "",
+        },
+        "activities": {first["id"]: first, second["id"]: second},
+        "gateways": {gateway["id"]: gateway, converge["id"]: converge},
+        "flows": {
+            "flow-start": {"id": "flow-start", "source": "start", "target": gateway["id"]},
+            "flow-first": {"id": "flow-first", "source": gateway["id"], "target": first["id"]},
+            "flow-second": {"id": "flow-second", "source": gateway["id"], "target": second["id"]},
+            "flow-first-converge": {
+                "id": "flow-first-converge",
+                "source": first["id"],
+                "target": converge["id"],
+            },
+            "flow-second-converge": {
+                "id": "flow-second-converge",
+                "source": second["id"],
+                "target": converge["id"],
+            },
+            "flow-end": {"id": "flow-end", "source": converge["id"], "target": "end"},
+        },
+    }
+
+
+def task_info(pipeline):
+    return {"id": 1, "task_url": "/task/1", "pipeline_tree": pipeline}
+
+
+def task_status(state, children):
+    return {
+        "state": state,
+        "name": "task",
+        "children": children,
+        "elapsed_time": 1,
+        "start_time": None,
+        "finish_time": None,
+    }
+
+
+def test_unfolds_static_subprocess_when_runtime_children_are_empty(parse_sops_pipeline_tree):
+    child_pipeline = linear_pipeline(service("child-1", "child 1"), service("child-2", "child 2"))
+    pipeline = linear_pipeline(subprocess("sub", "subprocess", child_pipeline))
+    status = task_status("RUNNING", {"sub": {"state": "RUNNING", "children": {}}})
+
+    result = parse_sops_pipeline_tree(task_info(pipeline), status, is_parse_all=True)
+
+    assert [step["step_name"] for step in result["step_data"]] == ["subprocess", "child 1", "child 2"]
+    assert [step["step_status"] for step in result["step_data"]] == ["执行中", "未执行", "未执行"]
+    assert result["total_step_num"] == 3
+
+
+def test_unfolds_short_parallel_subprocess_when_runtime_children_are_empty(parse_sops_pipeline_tree):
+    long_pipeline = linear_pipeline(service("long-child", "long child"))
+    short_pipeline = linear_pipeline(
+        service("short-child-1", "short child 1"), service("short-child-2", "short child 2")
+    )
+    pipeline = parallel_pipeline(
+        subprocess("long", "long subprocess", long_pipeline),
+        subprocess("short", "short subprocess", short_pipeline),
+    )
+    status = task_status(
+        "RUNNING",
+        {
+            "long": {
+                "state": "RUNNING",
+                "children": {"long-child": {"state": "RUNNING", "children": {}}},
+            },
+            "short": {"state": "FINISHED", "children": {}},
+        },
+    )
+
+    result = parse_sops_pipeline_tree(task_info(pipeline), status, is_parse_all=True)
+
+    assert [step["step_name"] for step in result["step_data"]] == [
+        "long subprocess",
+        "long child",
+        "short subprocess",
+        "short child 1",
+        "short child 2",
+    ]
+    assert result["total_step_num"] == 5
+
+
+def test_empty_runtime_children_keep_five_step_window_safe(parse_sops_pipeline_tree):
+    child_pipeline = linear_pipeline(
+        service("child-1", "child 1"),
+        service("child-2", "child 2"),
+        service("child-3", "child 3"),
+        service("child-4", "child 4"),
+        service("child-5", "child 5"),
+    )
+    pipeline = linear_pipeline(subprocess("sub", "subprocess", child_pipeline))
+    status = task_status("RUNNING", {"sub": {"state": "RUNNING", "children": {}}})
+
+    result = parse_sops_pipeline_tree(task_info(pipeline), status, is_parse_all=False)
+
+    assert [step["step_name"] for step in result["step_data"]] == ["subprocess", "child 1", "child 2"]
+    assert len(result["step_data"]) <= 5
+
+
+def test_successful_task_still_filters_nodes_without_runtime_status(parse_sops_pipeline_tree):
+    pipeline = linear_pipeline(service("executed", "executed"), service("not-selected", "not selected"))
+    status = task_status("FINISHED", {"executed": {"state": "FINISHED", "children": {}}})
+
+    result = parse_sops_pipeline_tree(task_info(pipeline), status, is_parse_all=True)
+
+    assert [step["step_name"] for step in result["step_data"]] == ["executed"]

--- a/src/manager/module_biz/test/test_platform_task.py
+++ b/src/manager/module_biz/test/test_platform_task.py
@@ -219,3 +219,24 @@ def test_successful_task_still_filters_nodes_without_runtime_status(parse_sops_p
     result = parse_sops_pipeline_tree(task_info(pipeline), status, is_parse_all=True)
 
     assert [step["step_name"] for step in result["step_data"]] == ["executed"]
+
+
+@pytest.mark.parametrize(
+    "state, expected_status",
+    [
+        ("SUSPENDED", "暂停"),
+        ("NODE_SUSPENDED", "暂停"),
+        ("REVOKED", "执行终止"),
+    ],
+)
+def test_unfinished_special_states_generate_broadcast_result(
+    parse_sops_pipeline_tree, state, expected_status
+):
+    pipeline = linear_pipeline(service("node", "node"))
+    status = task_status(state, {"node": {"state": state, "children": {}}})
+
+    result = parse_sops_pipeline_tree(task_info(pipeline), status, is_parse_all=False)
+
+    assert result["task_status"] == expected_status
+    assert result["current_step_num"] == 1
+    assert result["step_data"][0]["step_status"] == expected_status


### PR DESCRIPTION
## What changed

- Always unfold the static `pipeline` of a SOPS `SubProcess` when its runtime `children` is empty.
- Preserve the existing five-step main broadcast window, while supplementing the affected subprocess container and child nodes through the existing extra-step area.
- Avoid supplementing subprocesses that are still in `CREATED`.
- Preserve successful-task filtering for unselected branches.
- Handle missing running-leaf anchors and `SUSPENDED`, `NODE_SUSPENDED`, and `REVOKED` states safely.
- Add focused parser and rendered-broadcast regression tests.

## Why

A fast parallel subprocess can finish before the runtime status tree exposes its child nodes. The parser previously recursed only when runtime `children` was non-empty, and the existing five-step window could then hide the entire short branch from the actual broadcast.

## User impact

- The main five-line display, broadcast schedule, and message renderer remain unchanged.
- Only an executed subprocess with empty runtime `children` is supplemented after the existing ellipsis section.
- When child runtime status is unavailable, static child nodes keep the existing fallback status instead of being incorrectly inferred as successful.

## Validation

- `9 passed` in `src/manager/module_biz/test/test_platform_task.py`
- `black --check` passed for the new test file.
- `py_compile` passed for the changed Python files.
- `git diff --check master...HEAD` passed.

The neighboring Django test modules could not be collected in the current local environment because it differs from the repository's legacy dependency set (`RemovedInDjango30Warning` is unavailable and `faker` is not installed).
